### PR TITLE
docs: update workflow badge links [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 <p align="center">
 <a href="https://snapcraft.io/mosaic"><img src="https://snapcraft.io/mosaic/badge.svg" alt="Snap Status"></a>
-<a href="https://github.com/snapcrafters/mosaic/actions/workflows/release-to-candidate.yaml"><img src="https://github.com/snapcrafters/mosaic/actions/workflows/release-to-candidate.yaml/badge.svg"></a>
-<a href="https://github.com/snapcrafters/mosaic/actions/workflows/promote-to-stable.yaml"><img src="https://github.com/snapcrafters/mosaic/actions/workflows/promote-to-stable.yaml/badge.svg"></a>
+<a href="https://github.com/snapcrafters/mosaic/actions/workflows/release-to-candidate.yml"><img src="https://github.com/snapcrafters/mosaic/actions/workflows/release-to-candidate.yml/badge.svg"></a>
+<a href="https://github.com/snapcrafters/mosaic/actions/workflows/promote-to-stable.yml"><img src="https://github.com/snapcrafters/mosaic/actions/workflows/promote-to-stable.yml/badge.svg"></a>
 </p>
 
 <!-- Uncomment and modify this when you have a screenshot


### PR DESCRIPTION
## Summary
- Updates README workflow badge links to point at the canonical renamed workflow files.
- Keeps badge href and image URLs aligned with the standard `.yml` workflow filenames.

## Files
- `README.md`

## Replacements
- `promote-to-stable.yaml -> promote-to-stable.yml`
- `release-to-candidate.yaml -> release-to-candidate.yml`

## Verification
- `git diff --check`
- Commit message includes `[skip ci]`.

@jnsgruk please review.
